### PR TITLE
Use `grunt.loadNpmTaks` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install this grunt plugin next to your project's [grunt.js gruntfile][getting_st
 Then add this line to your project's `grunt.js` gruntfile.
 
 ```javascript
-task.loadNpmTasks('grunt-requirejs');
+grunt.loadNpmTasks('grunt-requirejs');
 ```
 
 ### Resources


### PR DESCRIPTION
Usually there's no `task` variable in a grunt.js file, so use `grunt.loadNpmTaks` instead
