### PR TITLE
Fix issue #6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "grunt": "~0.3.9",
     "requirejs": "~2.0.0",
-    "jQuery": "~1.7.2",
+    "jQuery": "1.7.4444",
     "almond": "~0.0.3"
   },
   "keywords": ["gruntplugin"]

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "grunt": "~0.3.9",
     "requirejs": "~2.0.0",
-    "jQuery": "1.7.4444",
+    "jQuery": "1.7.4",
     "almond": "~0.0.3"
   },
   "keywords": ["gruntplugin"]


### PR DESCRIPTION
By updating to version 1.7.4 it will allow the plugin to work in Windows
enviroments.
I've also removed the '~' so that npm will always install that specific version
of jQuery instead of floating around in versions like specified in the [npm
docs](http://npmjs.org/doc/json.html#Tilde-Version-Ranges)
