### PR TITLE
RequireJS optimization not being run if almond: false

### DIFF
--- a/tasks/require.js
+++ b/tasks/require.js
@@ -218,13 +218,13 @@ module.exports = function (grunt) {
 
         });
 
-      // check for callback, else mark as done
-      if (isFunction(options.cb)) {
-        options.cb(configClone);
-      } else {
-        options.done();
-      }
+    }
 
+    // check for callback, else mark as done
+    if (isFunction(options.cb)) {
+      options.cb(configClone);
+    } else {
+      options.done();
     }
   });
 

--- a/test/require_test.js
+++ b/test/require_test.js
@@ -25,5 +25,21 @@ exports['require'] = {
     test.equal(helperValuesSeriesB.message, 'Compressed size for module "b": \u001b[32m26\u001b[39m bytes gzipped (\u001b[32m6\u001b[39m bytes uncompressed).');
     
     test.done();
+  },
+  'almond helper runs callback even if almond: false': function(test) {
+    var wasCalled = false,
+        options = {
+          config: {
+            modules: []
+          },
+          almond: false,
+          cb: function() {
+            wasCalled = true;
+          }
+        };
+        
+    grunt.helper('almond', options);
+    test.equal(true, wasCalled);
+    test.done();
   }
 };


### PR DESCRIPTION
This may be a misunderstanding on my part, but it seems that optimization is never being run unless almond: true. This is rather counterintuitive, as documentation of the plugin also demonstrates that it should be possible to run the optimizations even without having almond replacement in place.

Anyhow, the attached test case illustrates the issue, and the patch fixes it so that the callback will always be called (and thus optimization is run) regardless whether "almondization" is enabled.
