### PR TITLE
added fix for -> TypeError: Cannot read property '_' of undefined

### DIFF
--- a/lib/almondify.js
+++ b/lib/almondify.js
@@ -17,7 +17,8 @@ exports.init = function(grunt) {
   // Prepare the auto insertion of the almond library
   // by modifying the users config
   return function(config) {
-    var configClone = grunt.utils._.clone(config);
+    //TODO: once grunt 0.4.0 is out change to -> grunt.util._.clone(config)re
+    var configClone = util._.clone(config);
     var moduleIterator = configClone.modules;
 
     // check if we should inline almond


### PR DESCRIPTION
When using grunt-0.4.0a an issue appears when running the requirejs task. 

TypeError: Cannot read property '_' of undefined

```
I changed the following:

var configClone = grunt.utils._.clone(config);

To:

//TODO: once grunt 0.4.0 is out change to -> grunt.util._.clone(config);
var configClone = util._.clone(config);
```

   Another offending line in the backbone builder also plays a role in this error.
   I will submit a pull request for that project as well.
