### PR TITLE
Allow to use custom r.js with relative path

### DIFF
--- a/examples/almond-text-plugin-project/node_modules/grunt-requirejs/lib/helper/rjsversion.js
+++ b/examples/almond-text-plugin-project/node_modules/grunt-requirejs/lib/helper/rjsversion.js
@@ -24,13 +24,13 @@ exports.init = function(grunt) {
     if (config.rjs) {
       var rjsPathname = config.rjs + '/bin/r.js';
 
-      // check if the custom version is available, then load & return the
+      // if the custom version is available, then load & return the
       // custom version, else default to the standard bundled requirejs
-      if (fs.existsSync(rjsPathname)) {
+      try {
         requirejs = require(rjsPathname);
         isDefaultVersion = false;
         return requirejs;
-      }
+      } catch (e) {}
 
     }
 


### PR DESCRIPTION
fs.existsSync works not like require statement, so relative paths are for r.js are impossible. try-catch solves that issue.
