### PR TITLE
Adding file name to file size report.

### DIFF
--- a/lib/helper/sizeInfo.js
+++ b/lib/helper/sizeInfo.js
@@ -31,6 +31,7 @@ exports.init = function(grunt) {
 
     // check if output is muted
     if (silent !== true) {
+      grunt.log.writeln('\n' + module.underline);
       grunt.log.writeln(messageUncompressed);
       grunt.log.writeln(messageCompressed);
     }


### PR DESCRIPTION
For the size report that is rendered post-optimization, there is no context for the different files. It renders something like this, which isn't very helpful if you have a bunch of modules:

![Screen Shot 2013-03-28 at 4 41 01 PM](https://f.cloud.github.com/assets/1161192/316089/4fc93ad4-9801-11e2-92b9-b1988e4aa446.png)

This PR adds a line of whitespace and the filename, so that it looks more like-a this:

![Screen Shot 2013-03-28 at 4 40 21 PM](https://f.cloud.github.com/assets/1161192/316102/abdbc4ea-9801-11e2-9c9d-bc067e1ad83d.png)

Let me know if there are any issues, and thanks for all the work!
