### PR TITLE
Update to multipage-shim example: mainConfigFile path made relative

### DIFF
--- a/examples/multipage-shim/Gruntfile.js
+++ b/examples/multipage-shim/Gruntfile.js
@@ -7,7 +7,7 @@ module.exports = function(grunt) {
       std: {
         options: {
           appDir: 'www',
-          mainConfigFile: '/www/js/common.js',
+          mainConfigFile: 'www/js/common.js',
           dir: 'www-built',
           modules: [
             //First set up the common build layer.


### PR DESCRIPTION
simply removed the '/' from the beginning of the mainConfigFile path, which allows it to work.
