### PR TITLE
Fix unexpected overriding of original almond source file when modules with additional including module

### DIFF
--- a/lib/almondify.js
+++ b/lib/almondify.js
@@ -61,8 +61,7 @@ exports.init = function(grunt) {
         // then append almond to them
         // else generate a new includes property
         if (util._.isArray(module.include)) {
-          configClone.modules[idx].include.unshift(configClone.modules[idx].name);
-          configClone.modules[idx].name = 'almond';
+          configClone.modules[idx].include.unshift('almond');
         } else {
           if (!util._.isUndefined(configClone.modules)) {
             configClone.modules[idx].include = ['almond'];


### PR DESCRIPTION
For example,

```
'almond': true,
'modules': [{
    'name': 'common',
    'include': ['jquery'],
},
```

Above build configuration overrides almond.js source file rather than append almond.js and jquery module into common module.
