### PR TITLE
Non-Almond also supports replaceRequireScript feature

### DIFF
--- a/lib/replace.js
+++ b/lib/replace.js
@@ -20,7 +20,7 @@ exports.init = function(grunt) {
     var deferred = Q.defer();
 
     // check if we should replace require with almond in html files
-    if (config.almond === true && util._.isArray(config.replaceRequireScript)) {
+    if (util._.isArray(config.replaceRequireScript)) {
 
       // iterate over all modules that are configured for replacement
       config.replaceRequireScript.forEach(function (entry, idx) {
@@ -55,8 +55,12 @@ exports.init = function(grunt) {
               // replace the attributes of requires script tag
               // with the 'almonded' version of the module
               var insertScript = util._.isUndefined(entry.modulePath) !== true ? entry.modulePath : elm.getAttribute('data-main');
-              elm.setAttribute('src', insertScript + '.js');
-              elm.removeAttribute('data-main');
+              if (config.almond === true) {
+                  elm.setAttribute('src', insertScript + '.js');
+                  elm.removeAttribute('data-main');
+              } else {
+                  elm.setAttribute('data-main', insertScript);
+              }
             }
 
           });


### PR DESCRIPTION
replaceRequireScript feature is not only useful for almond based bundle file but also require.js based.

Requirejs based optimization just change original value of `data-main` to bundled module path.

Check out `grunt requirejs:independent` task of https://github.com/cloudchen/requirejs-bundle-examples repository.
