### PR TITLE
Bug fixes with the replaceRequireScript option

### DIFF
--- a/lib/replace.js
+++ b/lib/replace.js
@@ -10,71 +10,49 @@ exports.init = function(grunt) {
   'use strict';
 
   // External libs.
-  var cheerio = require('cheerio');
-  var domino = require('domino');
   var Q = require('q');
-  // TODO: ditch this when grunt 0.4.0 is out
-  var util = grunt.util;
+  var jsdom = require('jsdom');
+  var fs = require('fs');
+  var rBody = /<body>/;
 
   return function(config) {
     var deferred = Q.defer();
 
-    // check if we should replace require with almond in html files
-    if (util._.isArray(config.replaceRequireScript)) {
+    // exit early if we're not replacing scripts
+    if(!(config.replaceRequireScript instanceof Array) || !config.replaceRequireScript.length) {
+      return config;
+    }
 
-      // iterate over all modules that are configured for replacement
-      config.replaceRequireScript.forEach(function (entry, idx) {
-        var files = grunt.file.expand(entry.files);
-        // log almond including
-        grunt.verbose.writeln('Replacing require script calls, with almond module files');
+    // iterate over all modules that are configured for replacement
+    config.replaceRequireScript.forEach(function (file, idx) {
+      var files = grunt.file.expand(file.files);
 
-        // iterate over found html files
-        files.forEach(function (file, index) {
-          // load file contents
-          var contents = String(grunt.file.read(file, 'utf-8'));
-          var window = domino.createWindow(contents);
-          var document = window.document;
-          // get the doctype back
-          var getDoctype = function (document) {
-            var html = '';
-            var node = document.doctype;
+      // iterate over found html files
+      files.forEach(function(file) {
+        var fileContents = fs.readFileSync(file, 'utf-8');
+        var hasBody = rBody.test(fileContents);
 
-            if (node) {
-                html = "<!DOCTYPE " + node.name + (node.publicId ? ' PUBLIC "' + node.publicId + '"' : '') + (!node.publicId && node.systemId ? ' SYSTEM' : '') + (node.systemId ? ' "' + node.systemId + '"' : '') + '>\n';
-            }
+        jsdom.env(fileContents, {
+          FetchExternalResources: false,
+          ProcessExternalResources: false
+        }, function(err, window) {
+          var scripts = window.document.querySelectorAll('script[data-main]');
 
-            return html;
-          };
-
-          // iterate over content nodes to find the correct script tags
-          var scriptTags = document.getElementsByTagName('script');
-          util._.each(scriptTags, function (elm, idx) {
-
-            // check for require js like script tags
-            if (elm.tagName.toLowerCase() === 'script' && elm.getAttribute('data-main') !== null) {
-              // replace the attributes of requires script tag
-              // with the 'almonded' version of the module
-              var insertScript = util._.isUndefined(entry.modulePath) !== true ? entry.modulePath : elm.getAttribute('data-main');
-              if (config.almond === true) {
-                  elm.setAttribute('src', insertScript + '.js');
-                  elm.removeAttribute('data-main');
-              } else {
-                  elm.setAttribute('data-main', insertScript);
-              }
-            }
-
+          [].slice.call(scripts).forEach(function(script) {
+            var insertScript = (file.modulePath || script.getAttribute('data-main'));
+            script.src = insertScript + '.js';
+            script.removeAttribute('data-main');
           });
 
-          // write out newly created file contents
-          grunt.file.write(file, getDoctype(document) + document.documentElement.outerHTML);
+          var html = hasBody ? window.document.innerHTML : window.document.body.innerHTML;
+          grunt.log.writeln('Updating requirejs script tag for file', file);
+          grunt.file.write(file, html);
           deferred.resolve(config);
         });
       });
+    });
 
-
-      return deferred.promise;
-    }
-
-    return config;
+    return deferred.promise;
   };
 };
+

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   "dependencies": {
     "requirejs": "2.1.x",
     "cheerio": "0.10.x",
-    "domino": "1.0.x",
     "almond": "0.2.x",
     "gzip-js": "0.3.x",
-    "q": "0.8.x"
+    "q": "0.8.x",
+    "jsdom": "0.8.x"
   },
   "devDependencies": {
     "grunt": "~0.4.0",

--- a/test/fixtures/replaceSingleAlmondDocFragment.html
+++ b/test/fixtures/replaceSingleAlmondDocFragment.html
@@ -1,0 +1,1 @@
+<script src="js/require.js" data-main="js/main"></script>

--- a/test/require_test.js
+++ b/test/require_test.js
@@ -164,10 +164,11 @@ exports['require'] = {
     };
 
     grunt.file.copy('test/fixtures/replaceSingleAlmond.html', 'tmp/replaceSingleAlmond.html');
-    replaceAlmondInHtmlFiles(config);
-    var replacedFileContents = grunt.file.read(config.replaceRequireScript[0].files[0]);
-    test.ok(replacedFileContents.search('<script src="js/main.js"></script>') > -1, 'should replace script tag ´src´ contents');
-    test.done();
+    replaceAlmondInHtmlFiles(config).then(function() {
+      var replacedFileContents = grunt.file.read(config.replaceRequireScript[0].files[0]);
+      test.ok(replacedFileContents.search('<script src="js/main.js"></script>') > -1, 'should replace script tag ´src´ contents');
+      test.done();
+    });
   },
 
   'requirejs script tag can be replaced with almondified script tag with no doctype declared (#59)': function(test) {
@@ -183,10 +184,11 @@ exports['require'] = {
     };
 
     grunt.file.copy('test/fixtures/replaceSingleAlmondNoDocType.html', 'tmp/replaceSingleAlmondNoDocType.html');
-    replaceAlmondInHtmlFiles(config);
-    var replacedFileContents = grunt.file.read(config.replaceRequireScript[0].files[0]);
-    test.ok(replacedFileContents.search('<script src="js/main.js"></script>') > -1, 'should replace script tag ´src´ contents');
-    test.done();
+    replaceAlmondInHtmlFiles(config).then(function() {
+      var replacedFileContents = grunt.file.read(config.replaceRequireScript[0].files[0]);
+      test.ok(replacedFileContents.search('<script src="js/main.js"></script>') > -1, 'should replace script tag ´src´ contents');
+      test.done();
+    });
   },
 
   'requirejs script tag can be replaced with almondified script tag & leaves attributes': function(test) {
@@ -202,10 +204,11 @@ exports['require'] = {
     };
 
     grunt.file.copy('test/fixtures/replaceSingleAlmondWithAttr.html', 'tmp/replaceSingleAlmondWithAttr.html');
-    replaceAlmondInHtmlFiles(config);
-    var replacedFileContents = grunt.file.read(config.replaceRequireScript[0].files[0]);
-    test.ok(replacedFileContents.search('<script src="js/main.js" async="true"></script>') > -1, 'should replace script tag ´src´ contents, but leaves the other attrs alone');
-    test.done();
+    replaceAlmondInHtmlFiles(config).then(function() {
+      var replacedFileContents = grunt.file.read(config.replaceRequireScript[0].files[0]);
+      test.ok(replacedFileContents.search('<script src="js/main.js" async="true"></script>') > -1, 'should replace script tag ´src´ contents, but leaves the other attrs alone');
+      test.done();
+    });
   },
 
   'requirejs script tag can be replaced with almondified script tag & leaves weird attributes': function(test) {
@@ -221,10 +224,11 @@ exports['require'] = {
     };
 
     grunt.file.copy('test/fixtures/replaceSingleAlmondWithComplexAttr.html', 'tmp/replaceSingleAlmondWithComplexAttr.html');
-    replaceAlmondInHtmlFiles(config);
-    var replacedFileContents = grunt.file.read(config.replaceRequireScript[0].files[0]);
-    test.ok(replacedFileContents.search('<script src="js/main.js" data-someweirdangularthingy="a > b" async="true"></script>') > -1, 'should replace script tag ´src´ contents, but leaves the other (complex) attrs alone');
-    test.done();
+    replaceAlmondInHtmlFiles(config).then(function() {
+      var replacedFileContents = grunt.file.read(config.replaceRequireScript[0].files[0]);
+      test.ok(replacedFileContents.search('<script src="js/main.js" data-someweirdangularthingy="a &gt; b" async="true"></script>') > -1, 'should replace script tag ´src´ contents, but leaves the other (complex) attrs alone');
+      test.done();
+    });
   },
 
   'multiple requirejs script tags can be replaced with almondified script tags': function(test) {
@@ -240,11 +244,12 @@ exports['require'] = {
     };
 
     grunt.file.copy('test/fixtures/replaceMultiAlmond.html', 'tmp/replaceMultiAlmond.html');
-    replaceAlmondInHtmlFiles(config);
-    var replacedFileContents = grunt.file.read(config.replaceRequireScript[0].files[0]);
-    test.ok(replacedFileContents.search('<script src="js/module1.js" async="true"></script>') > -1, 'should replace multiple script tag ´src´ contents, but leaves the other attrs alone');
-    test.ok(replacedFileContents.search('<script src="js/module2.js" async="true"></script>') > -1, 'should replace multiple script tag ´src´ contents, but leaves the other attrs alone');
-    test.done();
+    replaceAlmondInHtmlFiles(config).then(function() {
+      var replacedFileContents = grunt.file.read(config.replaceRequireScript[0].files[0]);
+      test.ok(replacedFileContents.search('<script src="js/module1.js" async="true"></script>') > -1, 'should replace multiple script tag ´src´ contents, but leaves the other attrs alone');
+      test.ok(replacedFileContents.search('<script src="js/module2.js" async="true"></script>') > -1, 'should replace multiple script tag ´src´ contents, but leaves the other attrs alone');
+      test.done();
+    });
   },
 
   'requirejs script tag can be replaced with almondified script tag in multiple files': function(test) {
@@ -261,12 +266,33 @@ exports['require'] = {
 
     grunt.file.copy('test/fixtures/replaceSingleAlmond.html', 'tmp/multi1.html');
     grunt.file.copy('test/fixtures/replaceSingleAlmond.html', 'tmp/multi2.html');
-    replaceAlmondInHtmlFiles(config);
-    var replacedFileContents1 = grunt.file.read(config.replaceRequireScript[0].files[0]);
-    var replacedFileContents2 = grunt.file.read(config.replaceRequireScript[0].files[1]);
-    test.ok(replacedFileContents1, 'should replace script tag ´src´ contents');
-    test.ok(replacedFileContents2.search('<script src="js/main.js"></script>') > -1, 'should replace script tag ´src´ contents');
-    test.done();
+    replaceAlmondInHtmlFiles(config).then(function() {
+      var replacedFileContents1 = grunt.file.read(config.replaceRequireScript[0].files[0]);
+      var replacedFileContents2 = grunt.file.read(config.replaceRequireScript[0].files[1]);
+      test.ok(replacedFileContents1, 'should replace script tag ´src´ contents');
+      test.ok(replacedFileContents2.search('<script src="js/main.js"></script>') > -1, 'should replace script tag ´src´ contents');
+      test.done();
+    });
+  },
+
+  'requirejs script tag should be replaced without HTML/BODY elements when the file contains a fragment': function(test) {
+    'use strict';
+    test.expect(1);
+    var config = {
+      replaceRequireScript: [{
+        files: ['tmp/replaceSingleAlmondDocFragment.html'],
+        module: 'main'
+      }],
+      modules: [{name: 'main'}],
+      almond: true
+    };
+
+    grunt.file.copy('test/fixtures/replaceSingleAlmondDocFragment.html', 'tmp/replaceSingleAlmondDocFragment.html');
+    replaceAlmondInHtmlFiles(config).then(function() {
+      var replacedFileContents = grunt.file.read(config.replaceRequireScript[0].files[0]);
+      test.ok(replacedFileContents.trim() === '<script src="js/main.js"></script>', 'should replace src attribute, and the resulting HTML only contains a script tag');
+      test.done();
+    });
   },
 
   'using removeCombined option with almond doesnt touch original almond file': function(test) {


### PR DESCRIPTION
This commit does two things:
1. Decouples the `replaceRequireScript` option from almond since its functionality doesn't actually depend on almond being used.
2. Gracefully handles document fragments in files defined in the `replaceRequireScript` option. Previously if a file specified in this option did not contain a `<html>` or `<body>` tag then those tags would be written in. So if a file had this fragment:

``` html
<script data-src="js/main" src="require.js"></script>
```

then resultant HTML would be:

``` html
<html><body><script src="js/main.js"></script></body></html>
```

Which isn't ideal. My particular use case is replacing script tags in mustache partials. I was able to simplify the logic quite a bit using jsdom.
