### PR TITLE
Fixed premature deferred.resolve() in lib/replace.js

### DIFF
--- a/lib/replace.js
+++ b/lib/replace.js
@@ -26,6 +26,7 @@ exports.init = function(grunt) {
     // iterate over all modules that are configured for replacement
     config.replaceRequireScript.forEach(function (file, idx) {
       var files = grunt.file.expand(file.files);
+      var filesEvaluated = 0;
 
       // iterate over found html files
       files.forEach(function(file) {
@@ -47,7 +48,12 @@ exports.init = function(grunt) {
           var html = hasBody ? window.document.innerHTML : window.document.body.innerHTML;
           grunt.log.writeln('Updating requirejs script tag for file', file);
           grunt.file.write(file, html);
-          deferred.resolve(config);
+
+          // only resolve after all files have been evaluated
+          filesEvaluated++;
+          if (filesEvaluated >= files.length) {
+            deferred.resolve(config);
+          }
         });
       });
     });

--- a/test/require_test.js
+++ b/test/require_test.js
@@ -269,7 +269,7 @@ exports['require'] = {
     replaceAlmondInHtmlFiles(config).then(function() {
       var replacedFileContents1 = grunt.file.read(config.replaceRequireScript[0].files[0]);
       var replacedFileContents2 = grunt.file.read(config.replaceRequireScript[0].files[1]);
-      test.ok(replacedFileContents1, 'should replace script tag ´src´ contents');
+      test.ok(replacedFileContents1.search('<script src="js/main.js"></script>') > -1, 'should replace script tag ´src´ contents');
       test.ok(replacedFileContents2.search('<script src="js/main.js"></script>') > -1, 'should replace script tag ´src´ contents');
       test.done();
     });


### PR DESCRIPTION
Premature `deferred.resolve()` occurs when passed `config.replaceRequireScript.files` array contains more than one file.
- Added `filesEvaluated` counter to `lib/replace.js`
- Patched associated nodeunit tests.
- Fixed failing unit test on replacedFileContents. Appears to have been a typo on the master branch that never did a `.search()` for the script tag.
