### PR TITLE
Fix almond path when '.js' appears more than once in path

### DIFF
--- a/lib/almondify.js
+++ b/lib/almondify.js
@@ -30,7 +30,7 @@ exports.init = function(grunt) {
       configClone.paths = configClone.paths || {};
 
       // set almond path
-      configClone.paths.almond = require.resolve('almond').replace('.js', '');
+      configClone.paths.almond = require.resolve('almond').replace(/\.js$/, '');
 
       // check if the 'removeCombined' option is enabled
       // then use a temporary almond file to ensure that the


### PR DESCRIPTION
Hi, I've changed the expression inside the _almondify_ module to build the path correctly. I ran into this issue when I've used a path like this: `'projects/fancy-projectname.js/node_modules/grunt-requirejs/...'`. The `.js` will appears more than once inside the path which ends up in not building correctly the complete file path for the `alomond.js` module.
